### PR TITLE
Removed Command test suite

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,9 +9,6 @@
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
-        <testsuite name="Commands">
-            <directory suffix="Test.php">./tests/Commands</directory>
-        </testsuite>
         <testsuite name="Features">
             <directory suffix="Test.php">./tests/Features</directory>
         </testsuite>


### PR DESCRIPTION
On PHPUnit > 9 the test suites failed because the matching directory couldn’t be found. This removed the folder from the configuration, therefore fixing the test suites.